### PR TITLE
Fixed issue where versions will not get unset because of some typo

### DIFF
--- a/src/Project/Project.php
+++ b/src/Project/Project.php
@@ -106,7 +106,7 @@ class Project implements \JsonSerializable
             unset($params['leadName']);
         }
         if ($this->versions === null or count($this->versions) === 0) {
-            unset($params['version']);
+            unset($params['versions']);
         }
 
         return $params;


### PR DESCRIPTION
Was investigating #5 and found out there is some bug in the `jsonSerialize` method.
`unset($params['version']);` will do nothing because `$params['version']` does not exist inside the class.

Replaced with `unset($params['versions']);` and now the updateProject method works fine.