### PR TITLE
added ability to get, create and update custom select options in custom fields

### DIFF
--- a/src/Field/FieldService.php
+++ b/src/Field/FieldService.php
@@ -96,8 +96,10 @@ class FieldService extends \JiraCloud\JiraClient
 
     /**
      * @param int $fieldId The custom field Id
-     * @return string|bool
+     *
      * @throws \JiraCloud\JiraException
+     *
+     * @return string|bool
      */
     public function getCustomFieldContexts(int $fieldId)
     {
@@ -110,12 +112,13 @@ class FieldService extends \JiraCloud\JiraClient
     }
 
     /**
-     * Get a custom fields options
+     * Get a custom fields options.
      *
-     * @param int $fieldId The custom field Id
+     * @param int $fieldId   The custom field Id
      * @param int $contextId Context ID related to the custom field
      *
      * @see https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-custom-field-options/#api-rest-api-3-field-fieldid-context-contextid-option-get
+     *
      * @throws \JiraCloud\JiraException
      *
      * @return string
@@ -131,13 +134,14 @@ class FieldService extends \JiraCloud\JiraClient
     }
 
     /**
-     * Create custom field options
+     * Create custom field options.
      *
-     * @param int $fieldId The custom field Id to add options to
-     * @param int $contextId Context ID related to the custom field
-     * @param array $options The options array
+     * @param int   $fieldId   The custom field Id to add options to
+     * @param int   $contextId Context ID related to the custom field
+     * @param array $options   The options array
      *
      * @see https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-custom-field-options/#api-rest-api-3-field-fieldid-context-contextid-option-post
+     *
      * @throws \JiraCloud\JiraException
      *
      * @return string
@@ -153,13 +157,14 @@ class FieldService extends \JiraCloud\JiraClient
     }
 
     /**
-     * Update a custom field options
+     * Update a custom field options.
      *
-     * @param int $fieldId The custom field Id
-     * @param int $contextId Context ID related to the custom field
-     * @param array $options The new options array
+     * @param int   $fieldId   The custom field Id
+     * @param int   $contextId Context ID related to the custom field
+     * @param array $options   The new options array
      *
      * @see https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-custom-field-options/#api-rest-api-3-field-fieldid-context-contextid-option-put
+     *
      * @throws \JiraCloud\JiraException
      *
      * @return string
@@ -173,5 +178,4 @@ class FieldService extends \JiraCloud\JiraClient
 
         return $ret;
     }
-
 }

--- a/src/Field/FieldService.php
+++ b/src/Field/FieldService.php
@@ -114,8 +114,8 @@ class FieldService extends \JiraCloud\JiraClient
     /**
      * Get a custom fields options.
      *
-     * @param int $fieldId   The custom field Id
-     * @param int $contextId Context ID related to the custom field
+     * @param int   $fieldId    The custom field Id
+     * @param int   $contextId  Context ID related to the custom field
      * @param array $paramArray Query parameters like 'startAt' and 'maxResults'
      *
      * @see https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-custom-field-options/#api-rest-api-3-field-fieldid-context-contextid-option-get

--- a/src/Field/FieldService.php
+++ b/src/Field/FieldService.php
@@ -116,6 +116,7 @@ class FieldService extends \JiraCloud\JiraClient
      *
      * @param int $fieldId   The custom field Id
      * @param int $contextId Context ID related to the custom field
+     * @param array $paramArray Query parameters like 'startAt' and 'maxResults'
      *
      * @see https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-custom-field-options/#api-rest-api-3-field-fieldid-context-contextid-option-get
      *
@@ -123,9 +124,9 @@ class FieldService extends \JiraCloud\JiraClient
      *
      * @return string
      */
-    public function getCustomFieldOptions(int $fieldId, int $contextId)
+    public function getCustomFieldOptions(int $fieldId, int $contextId, array $paramArray = [])
     {
-        $url = sprintf('%s/customfield_%s/context/%s/option', $this->uri, $fieldId, $contextId);
+        $url = sprintf('%s/customfield_%s/context/%s/option%s', $this->uri, $fieldId, $contextId, $this->toHttpQueryParameter($paramArray));
         $ret = $this->exec($url);
 
         $this->log->debug("get custom Field Options=\n".$ret);

--- a/src/Field/FieldService.php
+++ b/src/Field/FieldService.php
@@ -93,4 +93,85 @@ class FieldService extends \JiraCloud\JiraClient
 
         return $cf;
     }
+
+    /**
+     * @param int $fieldId The custom field Id
+     * @return string|bool
+     * @throws \JiraCloud\JiraException
+     */
+    public function getCustomFieldContexts(int $fieldId)
+    {
+        $url = sprintf('%s/customfield_%s/contexts', $this->uri, $fieldId);
+        $ret = $this->exec($url);
+
+        $this->log->debug("get custom Field Contexts=\n".$ret);
+
+        return $ret;
+    }
+
+    /**
+     * Get a custom fields options
+     *
+     * @param int $fieldId The custom field Id
+     * @param int $contextId Context ID related to the custom field
+     *
+     * @see https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-custom-field-options/#api-rest-api-3-field-fieldid-context-contextid-option-get
+     * @throws \JiraCloud\JiraException
+     *
+     * @return string
+     */
+    public function getCustomFieldOptions(int $fieldId, int $contextId)
+    {
+        $url = sprintf('%s/customfield_%s/context/%s/option', $this->uri, $fieldId, $contextId);
+        $ret = $this->exec($url);
+
+        $this->log->debug("get custom Field Options=\n".$ret);
+
+        return $ret;
+    }
+
+    /**
+     * Create custom field options
+     *
+     * @param int $fieldId The custom field Id to add options to
+     * @param int $contextId Context ID related to the custom field
+     * @param array $options The options array
+     *
+     * @see https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-custom-field-options/#api-rest-api-3-field-fieldid-context-contextid-option-post
+     * @throws \JiraCloud\JiraException
+     *
+     * @return string
+     */
+    public function createCustomFieldOptions(int $fieldId, int $contextId, array $options = [])
+    {
+        $url = sprintf('%s/customfield_%s/context/%s/option', $this->uri, $fieldId, $contextId);
+        $ret = $this->exec($url, json_encode($options), 'POST');
+
+        $this->log->debug("create custom Field Options=\n".$ret);
+
+        return $ret;
+    }
+
+    /**
+     * Update a custom field options
+     *
+     * @param int $fieldId The custom field Id
+     * @param int $contextId Context ID related to the custom field
+     * @param array $options The new options array
+     *
+     * @see https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-custom-field-options/#api-rest-api-3-field-fieldid-context-contextid-option-put
+     * @throws \JiraCloud\JiraException
+     *
+     * @return string
+     */
+    public function updateCustomFieldOptions(int $fieldId, int $contextId, array $options = [])
+    {
+        $url = sprintf('%s/customfield_%s/context/%s/option', $this->uri, $fieldId, $contextId);
+        $ret = $this->exec($url, json_encode($options), 'PUT');
+
+        $this->log->debug("update custom Field Options=\n".$ret);
+
+        return $ret;
+    }
+
 }


### PR DESCRIPTION
See https://github.com/lesstif/php-jira-rest-client/issues/465

I have no idea why the official V3 doc does not match what is actually working.... but here we go

I am talking about the fact, that I had to prefix the custom field ID inside the called URL with `customfield_`, otherwise it wouldn't work / actually give an error mentioning this problem.

So in the end 4 new methods have been added to the Fieldservice:

- `getCustomFieldContexts()` is needed to fetch the available context IDs for a given custom field (needed for all other methods added)
- `getCustomFieldOptions()` fetches the currently present options in JIRA including ther ID, disabled state and value
- `createCustomFieldOptions()` should be self explanatory - needs the context ID from above
- `updateCustomFieldOptions()` as well - needs the context ID from above

I also noticed, that one can get the `fieldId` and `contextId` from the URL when editing the available options in JIRA Cloud:
https://yoursubdomain.atlassian.net/secure/admin/EditCustomFieldOptions!default.jspa?atl_token=long-token&fieldConfigSchemeId=10152&fieldConfigId=10152&customFieldId=10048

So the `fieldConfigId` GET Parameter is the `contextId` and `customFieldId` is the `fieldId`

This might be usefull to add to the readme as well because its not really obvious... but let me know what you think