### PR TITLE
Allow issue description to be empty

### DIFF
--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -26,7 +26,7 @@ class IssueField implements \JsonSerializable
 
     public ?DateTimeInterface $updated = null;
 
-    public AtlassianDocumentFormat $description;
+    public ?AtlassianDocumentFormat $description;
 
     public ?Priority $priority = null;
 
@@ -269,7 +269,7 @@ class IssueField implements \JsonSerializable
      *
      * REST API V3 must use addDescriptionXXXX
      */
-    public function setDescription(AtlassianDocumentFormat $description): static
+    public function setDescription(?AtlassianDocumentFormat $description): static
     {
         if (!empty($description)) {
             $this->description = $description;


### PR DESCRIPTION
As also mentioned in #20 there is an exception if the issue you fetch from the cloud has an empty description. As many of our project managers are too lazy to fill them, it's a problem for my usecase.

This is a quick fix to make it work, I'm unsure if it has any unwanted side effects. 