### PR TITLE
Update the Issue/IssueField::addCustomField function

### DIFF
--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -4,6 +4,7 @@ namespace JiraCloud\Issue;
 
 use AllowDynamicProperties;
 use DateTimeInterface;
+use DH\Adf\Node\Block\Document;
 use JiraCloud\ADF\ADFMarkType;
 use JiraCloud\ADF\AtlassianDocumentFormat;
 use JiraCloud\ClassSerialize;
@@ -154,7 +155,7 @@ class IssueField implements \JsonSerializable
         return $this->customFields;
     }
 
-    public function addCustomField(string $key, string|int|float $value): static
+    public function addCustomField(string $key, string|int|float|array|Document $value): static
     {
         $this->customFields[$key] = $value;
 


### PR DESCRIPTION
Add array & Document as optional parameter types to support multi-select fields & textarea fields. 
The array type is already available in the [php-jira-rest-client](https://github.com/lesstif/php-jira-rest-client) library and just seems to be missing here.
The API V3 requires ADF Document objects for textarea values. As a result the addCustomField function requires it as an optional input type.