### PR TITLE
Allow NULL for setParent

### DIFF
--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -362,7 +362,7 @@ class IssueField implements \JsonSerializable
         return $this;
     }
 
-    public function setParent(Issue $parent): void
+    public function setParent(?Issue $parent): void
     {
         $this->parent = $parent;
     }


### PR DESCRIPTION
Latest version of PHP 8.1 is raising an error for issue fields where parent is NULL

```
In JsonMapper.php line 216:
JSON property "parent" in class "JiraRestApi\Issue\IssueField" must not be NULL  
```

According to the docblock, this can be NULL, so I think the param should be nullable