### PR TITLE
Initialize typed property "labels" so it can be accessed even if empty

### DIFF
--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -103,7 +103,7 @@ class IssueField implements \JsonSerializable
     public function __construct($updateIssue = false)
     {
         $this->labels = [];
-        
+
         if ($updateIssue !== true) {
             $this->project = new \JiraCloud\Project\Project();
 

--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -102,6 +102,8 @@ class IssueField implements \JsonSerializable
 
     public function __construct($updateIssue = false)
     {
+        $this->labels = [];
+        
         if ($updateIssue !== true) {
             $this->project = new \JiraCloud\Project\Project();
 


### PR DESCRIPTION
Fix "Typed property JiraCloud\Issue\IssueField::$labels must not be accessed before initialization" when trying to access labels of a retrieved issue.