### PR TITLE
Fix timeout option

### DIFF
--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -147,6 +147,7 @@ class JiraClient
             curl_setopt($ch, CURLOPT_SSLKEYPASSWD, $this->getConfiguration()->isCurlOptSslKeyPassword());
         }
         if ($this->getConfiguration()->getTimeout()) {
+            curl_setopt($ch, CURLOPT_TIMEOUT, $this->getConfiguration()->getTimeout());
             curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->getConfiguration()->getTimeout());
         }
 


### PR DESCRIPTION
Looks like currently the client could get stuck in infinite wait and there isn't any way to limit this.