### PR TITLE
fix: Make labels nullable by default

### DIFF
--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -35,7 +35,7 @@ class IssueField implements \JsonSerializable
 
     public ?IssueStatus $status = null;
 
-    public array $labels;
+    public ?array $labels = null;
 
     public Project $project;
 
@@ -102,8 +102,6 @@ class IssueField implements \JsonSerializable
 
     public function __construct($updateIssue = false)
     {
-        $this->labels = [];
-
         if ($updateIssue !== true) {
             $this->project = new \JiraCloud\Project\Project();
 


### PR DESCRIPTION
When updating an issue, if you don't set the labels, the post_data JSON is generated with an empty array for labels, causing a problem by emptying them. Previously, this was the default behavior. I modified it to create null instead, ensuring labels are only emptied if explicitly set as an empty array in the code. Before this change, you couldn't set the property to null because it was defined as a non-null array. I believe the default behavior should be as I implemented: labels should only change if the property is explicitly set.