### PR TITLE
Bugfix/organisation get errors

### DIFF
--- a/src/ServiceDesk/Organisation/OrganisationService.php
+++ b/src/ServiceDesk/Organisation/OrganisationService.php
@@ -198,7 +198,7 @@ class OrganisationService
     private function createOrganisation(string $data): Organisation
     {
         return $this->jsonMapper->map(
-            json_decode($data, false, 512, JSON_THROW_ON_ERROR),
+            json_decode($data, true, 512, JSON_THROW_ON_ERROR),
             new Organisation()
         );
     }

--- a/src/ServiceDesk/Organisation/OrganisationService.php
+++ b/src/ServiceDesk/Organisation/OrganisationService.php
@@ -16,7 +16,7 @@ use Psr\Log\LoggerInterface;
 class OrganisationService
 {
     private ServiceDeskClient $client;
-    private string $uri = '/servicedeskapi/organization';
+    private string $uri = '/organization';
     private LoggerInterface $logger;
     private JsonMapper $jsonMapper;
 

--- a/tests/ServiceDesk/Organisation/OrganisationServiceTest.php
+++ b/tests/ServiceDesk/Organisation/OrganisationServiceTest.php
@@ -73,6 +73,7 @@ class OrganisationServiceTest extends TestCase
         $item = [
             'id' => $id,
             'name' => 'Test organisation',
+            '_links' => ['self' => 'http://example.com/rest/servicedeskapi/organization/' . $id],
         ];
         $url = 'https://example.com/organisation/get';
 
@@ -205,6 +206,8 @@ class OrganisationServiceTest extends TestCase
     private function createClient(): MockObject|ServiceDeskClient
     {
         $mapper = new JsonMapper();
+        // Turned off as per ServiceDeskClient.
+        $mapper->bEnforceMapType = false;
 
         $client = $this->createMock(ServiceDeskClient::class);
         $client->method('getMapper')->willReturn($mapper);

--- a/tests/ServiceDesk/Organisation/OrganisationServiceTest.php
+++ b/tests/ServiceDesk/Organisation/OrganisationServiceTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class OrganisationServiceTest extends TestCase
 {
-    private string $uri = '/servicedeskapi/organization';
+    private string $uri = '/organization';
 
     public function testCreate(): void
     {


### PR DESCRIPTION
I have encountered two issues while trying to get an organization from JiraServiceDesk:

- The ServiceDeskClient used by OrganisationService appends `servicedeskapi` resulting in a duplicate in the uri: https://github.com/lesstif/php-JiraCloud-RESTAPI/blob/main/src/ServiceDesk/ServiceDeskClient.php#L31
- The links property returned by Jira is a json object not an array, resulting in an Organisation() mapping error

Both issues have been fixed here and tests updated.