### PR TITLE
Bugfix: Empty Encoding causes Write Error

### DIFF
--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -236,7 +236,10 @@ class JiraClient
             curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         }
 
-        curl_setopt($ch, CURLOPT_ENCODING, '');
+        if (\PHP_VERSION_ID < 80307) {
+            // See https://github.com/php/php-src/issues/14184
+            curl_setopt($ch, CURLOPT_ENCODING, '');
+        }
 
         curl_setopt(
             $ch,


### PR DESCRIPTION
Passing an empty string for the cURL option `CURLOPT_ENCODING` causes a write error due to a 0-length write in the underlying `libcurl`, [starting in PHP 8.3.7](https://github.com/php/php-src/issues/14184).

This has been fixed in cURL and, if I understand correctly, the appropriate fix _will_ be to use the following:

```php
curl_setopt($ch, CURLOPT_ACCEPT_ENCODING, '');
```

Unfortunately that has not landed in PHP yet and as of PHP 8.3.8 still causes the error.
So for now, I've just restricted auto-detection of encoding to PHP versions below 8.3.7.