### PR TITLE
do not lie about supported dependency versions (jsonmapper 5.x)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.1",
         "ext-curl": "*",
         "ext-json": "*",
-        "netresearch/jsonmapper": "^3.0|^4.0|^5.0",
+        "netresearch/jsonmapper": "^3.0|^4.0",
         "monolog/monolog": "^2.0|^3.0",
         "vlucas/phpdotenv": "^5.0|^6.0",
         "damienharper/adf-tools": "^1.0"


### PR DESCRIPTION
claiming to support jsonmapper ^5.0 obviously was not true two years ago, as that version was only releases a few days ago, and using it instantly breaks things, see #87 

So lets stay on 4.x until we can deal with 5.x

Should fix #87 