### PR TITLE
AtlassianDocumentFormat allow string into constructor

### DIFF
--- a/src/ADF/AtlassianDocumentFormat.php
+++ b/src/ADF/AtlassianDocumentFormat.php
@@ -24,8 +24,7 @@ class AtlassianDocumentFormat implements \JsonSerializable
             $this->document = (new Document())
                 ->paragraph()
                 ->text($document)
-                ->end()
-            ;
+                ->end();
 
             return;
         }

--- a/src/ADF/AtlassianDocumentFormat.php
+++ b/src/ADF/AtlassianDocumentFormat.php
@@ -18,8 +18,18 @@ class AtlassianDocumentFormat implements \JsonSerializable
 
     private ?Document $document = null;
 
-    public function __construct(Document|Node $document)
+    public function __construct(Document|Node|string $document)
     {
+        if (is_string($document)) {
+            $this->document = (new Document())
+                ->paragraph()
+                ->text($document)
+                ->end()
+            ;
+
+            return;
+        }
+
         $this->document = $document;
     }
 


### PR DESCRIPTION
Allow to have string description for `AtlassianDocumentFormat` and for string into a paragraph.

Can fix the error "Uncaught TypeError: JiraCloud\ADF\AtlassianDocumentFormat::__construct(): Argument #1 ($document) must be of type DH\Adf\Node\Block\Document|DH\Adf\Node\Node, string given, called in .../vendor/netresearch/jsonmapper/src/JsonMapper.php on line 653 and defined in .../vendor/lesstif/jira-cloud-restapi/src/ADF/AtlassianDocumentFormat.php:21" (See issue #52).