### PR TITLE
Fixes deprecation notices about dynamic properties creation

### DIFF
--- a/src/DynamicPropertiesTrait.php
+++ b/src/DynamicPropertiesTrait.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JiraCloud;
+
+/**
+ * Defines a trait that allows to dynamically assign properties to objects as this has been deprecated in PHP8.2.
+ */
+trait DynamicPropertiesTrait
+{
+    /** @var array<string, mixed> */
+    protected array $dynamicProperties = [];
+
+    /**
+     * Attempts to retrieve a dynamic property from {@link static::$dynamicProperties}.
+     *
+     * @param string $name
+     * @return mixed The requested value if found, `null` otherwise.
+     */
+    public function __get(string $name): mixed
+    {
+        return $this->dynamicProperties[$name] ?? null;
+    }
+
+    /**
+     * Returns whether the dynamic property `$name` is set (not `null`!) in {@link static::$dynamicProperties}.
+     *
+     * @param string $name
+     * @return bool
+     */
+    public function __isset(string $name): bool
+    {
+        return isset($this->dynamicProperties[$name]);
+    }
+
+    /**
+     * Applies `$value` using `$name` as key on {@link static::$dynamicProperties}.
+     *
+     * @param string $name
+     * @param        $value
+     * @return void
+     */
+    public function __set(string $name, $value): void
+    {
+        $this->dynamicProperties[$name] = $value;
+    }
+
+    /**
+     * Accessor for {@link static::$dynamicProperties}.
+     *
+     * @return array
+     */
+    public function getDynamicProperties(): array
+    {
+        return $this->dynamicProperties;
+    }
+}

--- a/src/Issue/History.php
+++ b/src/Issue/History.php
@@ -2,6 +2,8 @@
 
 namespace JiraCloud\Issue;
 
+use JiraCloud\DynamicPropertiesTrait;
+
 /**
  * ChangeLog History.
  *
@@ -9,6 +11,8 @@ namespace JiraCloud\Issue;
  */
 class History implements \JsonSerializable
 {
+    use DynamicPropertiesTrait;
+    
     public int $id;
 
     public Reporter $author;

--- a/src/Issue/Issue.php
+++ b/src/Issue/Issue.php
@@ -2,8 +2,12 @@
 
 namespace JiraCloud\Issue;
 
+use JiraCloud\DynamicPropertiesTrait;
+
 class Issue implements \JsonSerializable
 {
+    use DynamicPropertiesTrait;
+
     /**
      * return only if Project query by key(not id).
      */

--- a/src/Issue/IssueSearchResult.php
+++ b/src/Issue/IssueSearchResult.php
@@ -2,11 +2,15 @@
 
 namespace JiraCloud\Issue;
 
+use JiraCloud\DynamicPropertiesTrait;
+
 /**
  * Issue search result.
  */
 class IssueSearchResult
 {
+    use DynamicPropertiesTrait;
+
     /**
      * @var string
      */

--- a/src/Issue/Visibility.php
+++ b/src/Issue/Visibility.php
@@ -2,8 +2,12 @@
 
 namespace JiraCloud\Issue;
 
+use JiraCloud\DynamicPropertiesTrait;
+
 class Visibility implements \JsonSerializable
 {
+    use DynamicPropertiesTrait;
+
     private string $type;
     private string $value;
 

--- a/src/Sprint/Sprint.php
+++ b/src/Sprint/Sprint.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace JiraCloud\Sprint;
 
+use JiraCloud\DynamicPropertiesTrait;
 use JiraCloud\JsonSerializableTrait;
 
 class Sprint implements \JsonSerializable
 {
     use JsonSerializableTrait;
+    use DynamicPropertiesTrait;
 
     public string $self;
 


### PR DESCRIPTION
Fixes that deprecation notices about dynamic properties creation are issued when used with PHP8.2 and greater.

Dynamic property creation has been deprecated in PHP8.2 and are likely to be removed from PHP in an upcoming version.
Since JIRA allows to create custom fields, this will lead to errors in upcoming PHP versions. Thus a trait was added that allows to create dynamic properties using magic method `__set`, retrieve them via magic method `__get` and check their existance via magic method `__isset`.

The trait was only assigned to a couple of classes yet but can be assigned whenever the need arises.

Without the change you might encounter the following output using PHP8.2 and above:
```
Deprecated: Creation of dynamic property JiraCloud\Sprint\Sprint::$createdDate is deprecated in /.../vendor/lesstif/jira-cloud-restapi/src/JsonMapperHelper.php on line 25
```