### PR TITLE
Add paginated projects endpoint (replacement for deprecated get all projects)

### DIFF
--- a/src/Project/PaginatedResult.php
+++ b/src/Project/PaginatedResult.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace JiraCloud\Project;
+
+/**
+ * Paginated Result object for BoardService.
+ */
+class PaginatedResult
+{
+    /**
+     * @var int
+     */
+    public $startAt;
+
+    /**
+     * @var int
+     */
+    public $maxResults;
+
+    /**
+     * @var string
+     */
+    public $nextPage;
+
+    /**
+     * @var string
+     */
+    public $self;
+
+    /**
+     * @var int
+     */
+    public $total;
+
+    /**
+     * @var array
+     */
+    public $values;
+
+    /**
+     * @var bool
+     */
+    public $isLast;
+
+    /**
+     * @return int
+     */
+    public function getStartAt()
+    {
+        return $this->startAt;
+    }
+
+    /**
+     * @param int $startAt
+     */
+    public function setStartAt($startAt)
+    {
+        $this->startAt = $startAt;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxResults()
+    {
+        return $this->maxResults;
+    }
+
+    /**
+     * @param int $maxResults
+     */
+    public function setMaxResults($maxResults)
+    {
+        $this->maxResults = $maxResults;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNextPage()
+    {
+        return $this->nextPage;
+    }
+
+    /**
+     * @param string $nextPage
+     */
+    public function setNextPage($nextPage)
+    {
+        $this->nextPage = $nextPage;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSelf()
+    {
+        return $this->self;
+    }
+
+    /**
+     * @param int $nextPage
+     */
+    public function setSelf($self)
+    {
+        $this->self = $self;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTotal()
+    {
+        return $this->total;
+    }
+
+    /**
+     * @param int $total
+     */
+    public function setTotal($total)
+    {
+        $this->total = $total;
+    }
+
+    /**
+     * @return array
+     */
+    public function getValues()
+    {
+        return $this->values;
+    }
+
+    /**
+     * @param array $values
+     */
+    public function setValues($values)
+    {
+        $this->values = $values;
+    }
+
+    /**
+     * @param int $index
+     *
+     * @return mixed
+     */
+    public function getValue($index)
+    {
+        return $this->values[$index];
+    }
+
+    /**
+     * @param bool $isLast
+     */
+    public function setIsLast($isLast)
+    {
+        $this->isLast = $isLast;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIsLast()
+    {
+        return $this->isLast;
+    }
+}

--- a/src/Project/PaginatedResult.php
+++ b/src/Project/PaginatedResult.php
@@ -99,7 +99,7 @@ class PaginatedResult
     }
 
     /**
-     * @param int $nextPage
+     * @param string $self
      */
     public function setSelf($self)
     {

--- a/src/Project/ProjectService.php
+++ b/src/Project/ProjectService.php
@@ -46,7 +46,7 @@ class ProjectService extends \JiraCloud\JiraClient
      */
     public function getProjectsPaginated($paramArray = []): PaginatedResult
     {
-        $ret = $this->exec($this->uri . '/search' . $this->toHttpQueryParameter($paramArray), null);
+        $ret = $this->exec($this->uri.'/search'.$this->toHttpQueryParameter($paramArray), null);
 
         $decodedRet = json_decode($ret, false);
 
@@ -58,7 +58,7 @@ class ProjectService extends \JiraCloud\JiraClient
 
         $prjsPag = $this->json_mapper->map(
             $decodedRet,
-            new PaginatedResult
+            new PaginatedResult()
         );
 
         return $prjsPag;

--- a/src/Project/ProjectService.php
+++ b/src/Project/ProjectService.php
@@ -36,6 +36,35 @@ class ProjectService extends \JiraCloud\JiraClient
     }
 
     /**
+     * get a paginated list of projects.
+     *
+     * @param array $paramArray
+     *
+     * @throws \JiraCloud\JiraException
+     *
+     * @return PaginatedResult
+     */
+    public function getProjectsPaginated($paramArray = []): PaginatedResult
+    {
+        $ret = $this->exec($this->uri . '/search' . $this->toHttpQueryParameter($paramArray), null);
+
+        $decodedRet = json_decode($ret, false);
+
+        $decodedRet->values = $this->json_mapper->mapArray(
+            $decodedRet->values,
+            new \ArrayObject(),
+            Project::class
+        );
+
+        $prjsPag = $this->json_mapper->map(
+            $decodedRet,
+            new PaginatedResult
+        );
+
+        return $prjsPag;
+    }
+
+    /**
      * get Project id By Project Key.
      * throws HTTPException if the project is not found, or the calling user does not have permission or view it.
      *

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -39,6 +39,32 @@ class ProjectTest extends TestCase
 
         return $projKey;
     }
+
+    /**
+     * @test
+     *
+     */
+    public function get_project_paginated_lists() : string
+    {
+        $projKey = 'TEST';
+        try {
+            $proj = new ProjectService();
+
+            $prjsPag = $proj->getProjectsPaginated();
+
+            foreach ($prjsPag->values as $p) {
+                $this->assertTrue($p instanceof Project);
+                $this->assertTrue(strlen($p->key) > 0);
+                $this->assertTrue(!empty($p->id));
+                $this->assertTrue(strlen($p->name) > 0);
+            }
+        } catch (\Exception $e) {
+            $this->fail('get_project_paginated_lists ' . $e->getMessage());
+        }
+
+        return $projKey;
+    }
+
     /**
      * @test
      * @depends get_project_lists


### PR DESCRIPTION
Add support for "Get projects paginated" endpoint

The previously available "Get all projects" endpoint is deprecated ([doc](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-projects/#api-rest-api-3-project-get)).
This change adds support for the new paginated endpoint that supports
search and pagination, while keeping the deprecated endpoint for
backward compatibility.